### PR TITLE
Converter translations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,66 @@ npm i sdc-qrf
 ```
 
 P.S. the package was allocated from https://github.com/beda-software/sdc-ide with commits history
+
+## Translation
+
+The FHIR ↔ FCE converter supports the [`translation`](http://hl7.org/fhir/StructureDefinition/translation) primitive extension on fields such as `Questionnaire.title` and `Questionnaire.item.text`.
+
+**FHIR**
+
+```yaml
+item:
+    - linkId: chief-complaint
+      type: string
+      text: Chief complaint
+      _text:
+          extension:
+              - url: http://hl7.org/fhir/StructureDefinition/translation
+                extension:
+                    - url: lang
+                      valueCode: de
+                    - url: content
+                      valueString: Hauptbeschwerde
+              - url: http://hl7.org/fhir/StructureDefinition/translation
+                extension:
+                    - url: lang
+                      valueCode: fr
+                    - url: content
+                      valueString: Motif de consultation
+```
+
+**FCE** (`toFirstClassExtension` / `fromFirstClassExtension`)
+
+```yaml
+item:
+    - linkId: chief-complaint
+      type: string
+      text: Chief complaint
+      _text:
+          translation:
+              - lang: de
+                content: Hauptbeschwerde
+              - lang: fr
+                content: Motif de consultation
+```
+
+### `translateQuestionnaire`
+
+To bake a single language into a FHIR Questionnaire before converting to FCE (resolves matching translations and strips translation extensions):
+
+```ts
+import { toFirstClassExtension, translateQuestionnaire } from 'sdc-qrf';
+
+const fceQuestionnaire = toFirstClassExtension(translateQuestionnaire(questionnaire, 'fr'));
+```
+
+`translateQuestionnaire(questionnaire, 'fr')` produces:
+
+```yaml
+item:
+    - linkId: chief-complaint
+      type: string
+      text: Motif de consultation
+```
+
+If the requested language is missing, the original value is kept and translation extensions are still removed.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ item:
 
 ### `translateQuestionnaire`
 
-To bake a single language into a FHIR Questionnaire before converting to FCE (resolves matching translations and strips translation extensions):
+To bake a single language into a FHIR Questionnaire before converting to FCE (resolves matching translations, keeps translation extensions, and stashes the original value):
 
 ```ts
 import { toFirstClassExtension, translateQuestionnaire } from 'sdc-qrf';
@@ -65,10 +65,31 @@ const fceQuestionnaire = toFirstClassExtension(translateQuestionnaire(questionna
 `translateQuestionnaire(questionnaire, 'fr')` produces:
 
 ```yaml
+language: fr
 item:
     - linkId: chief-complaint
       type: string
       text: Motif de consultation
+      _text:
+          extension:
+              - url: http://hl7.org/fhir/StructureDefinition/translation
+                extension:
+                    - url: lang
+                      valueCode: de
+                    - url: content
+                      valueString: Hauptbeschwerde
+              - url: http://hl7.org/fhir/StructureDefinition/translation
+                extension:
+                    - url: lang
+                      valueCode: fr
+                    - url: content
+                      valueString: Motif de consultation
+              - url: http://hl7.org/fhir/StructureDefinition/translation
+                extension:
+                    - url: lang
+                      valueCode: en
+                    - url: content
+                      valueString: Chief complaint
 ```
 
-If the requested language is missing, the original value is kept and translation extensions are still removed.
+Before replacing a value, the original is stored as a translation extension using `Questionnaire.language` (or `en` if missing). If at least one translation is applied, `Questionnaire.language` is set to the requested language. If the requested language is missing, the original value and all translation extensions are left unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sdc-qrf",
-    "version": "1.1.0-alpha.1",
+    "version": "1.1.0-alpha.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sdc-qrf",
-            "version": "1.1.0-alpha.1",
+            "version": "1.1.0-alpha.11",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.5.1",

--- a/src/converter/__tests__/fce.test.ts
+++ b/src/converter/__tests__/fce.test.ts
@@ -37,6 +37,7 @@ import fce_practitioner_create_structure_map from './resources/questionnaire_fce
 import fce_practitioner_edit from './resources/questionnaire_fce/practitioner_edit.json';
 import fce_practitioner_role_create from './resources/questionnaire_fce/practitioner_role_create.json';
 import fce_printable_elements from './resources/questionnaire_fce/printable_elements.json';
+import fce_translation from './resources/questionnaire_fce/translation.json';
 import fce_public_appointment from './resources/questionnaire_fce/public_appointment.json';
 import fce_questionnaire_variable from './resources/questionnaire_fce/questionnaire_variable.json';
 import fce_review_of_systems from './resources/questionnaire_fce/review_of_systems.json';
@@ -83,6 +84,7 @@ import fhir_practitioner_create_structure_map from './resources/questionnaire_fh
 import fhir_practitioner_edit from './resources/questionnaire_fhir/practitioner_edit.json';
 import fhir_practitioner_role_create from './resources/questionnaire_fhir/practitioner_role_create.json';
 import fhir_printable_elements from './resources/questionnaire_fhir/printable_elements.json';
+import fhir_translation from './resources/questionnaire_fhir/translation.json';
 import fhir_public_appointment from './resources/questionnaire_fhir/public_appointment.json';
 import fhir_questionnaire_variable from './resources/questionnaire_fhir/questionnaire_variable.json';
 import fhir_review_of_systems from './resources/questionnaire_fhir/review_of_systems.json';
@@ -150,6 +152,7 @@ describe('Questionanire and QuestionnaireResponses transformation', () => {
         ['column-width', fhir_column_width, fce_column_width],
         ['mapping-inline', fhir_mapping_inline, fce_mapping_inline],
         ['printable-elements', fhir_printable_elements, fce_printable_elements],
+        ['translation', fhir_translation, fce_translation],
     ])('Each FHIR Questionnaire should convert to FCE %s', async (_, fhir_questionnaire, fce_questionnaire) => {
         expect(toFirstClassExtension(fhir_questionnaire as FHIRQuestionnaire)).toStrictEqual(fce_questionnaire);
     });
@@ -203,6 +206,7 @@ describe('Questionanire and QuestionnaireResponses transformation', () => {
         ['column-width', fce_column_width, fhir_column_width],
         ['mapping-inline', fce_mapping_inline, fhir_mapping_inline],
         ['printable-elements', fce_printable_elements, fhir_printable_elements],
+        ['translation', fce_translation, fhir_translation],
     ])('Each FCE Questionnaire should convert to FHIR %s', async (_, fce_questionnaire, fhir_questionnaire) => {
         expect(sortExtensionsList(fromFirstClassExtension(fce_questionnaire as FCEQuestionnaire))).toStrictEqual(
             sortExtensionsList(fhir_questionnaire),

--- a/src/converter/__tests__/resources/questionnaire_fce/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation.json
@@ -1,0 +1,40 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-example",
+    "status": "active",
+    "title": "Chief complaint form",
+    "_title": {
+        "translation": [
+            {
+                "lang": "de",
+                "content": "Formular für Hauptbeschwerde"
+            },
+            {
+                "lang": "fr",
+                "content": "Formulaire de motif de consultation"
+            }
+        ]
+    },
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "_text": {
+                "translation": [
+                    {
+                        "lang": "de",
+                        "content": "Hauptbeschwerde"
+                    },
+                    {
+                        "lang": "fr",
+                        "content": "Motif de consultation"
+                    }
+                ]
+            }
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/__tests__/resources/questionnaire_fhir/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fhir/translation.json
@@ -1,0 +1,76 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-example",
+    "status": "active",
+    "title": "Chief complaint form",
+    "_title": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {
+                        "url": "lang",
+                        "valueCode": "de"
+                    },
+                    {
+                        "url": "content",
+                        "valueString": "Formular für Hauptbeschwerde"
+                    }
+                ]
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {
+                        "url": "lang",
+                        "valueCode": "fr"
+                    },
+                    {
+                        "url": "content",
+                        "valueString": "Formulaire de motif de consultation"
+                    }
+                ]
+            }
+        ]
+    },
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Hauptbeschwerde"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Motif de consultation"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/__tests__/translateQuestionnaire.test.ts
+++ b/src/converter/__tests__/translateQuestionnaire.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { translateQuestionnaire } from '../fhirToFce/translateQuestionnaire';
+import fhir_gad_7 from './resources/questionnaire_fhir/gad_7.json';
 
 const translationQuestionnaire: FHIRQuestionnaire = {
     resourceType: 'Questionnaire',
@@ -72,35 +73,380 @@ const translationQuestionnaire: FHIRQuestionnaire = {
 };
 
 describe('translateQuestionnaire', () => {
-    test('translates item.text for the requested language', () => {
+    test('translates item.text and nested item.text for the requested language', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'fr');
 
-        expect(result.item?.[0]?.text).toBe('Motif de consultation');
-        expect(result.item?.[0]?._text).toBeUndefined();
-    });
-
-    test('translates nested item.text', () => {
-        const result = translateQuestionnaire(translationQuestionnaire, 'fr');
-
-        expect(result.item?.[0]?.item?.[0]?.text).toBe('Détails');
-        expect(result.item?.[0]?.item?.[0]?._text).toBeUndefined();
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "_title": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formular für Hauptbeschwerde",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "fr",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formulaire de motif de consultation",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "en",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Chief complaint form",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+              ],
+            },
+            "item": [
+              {
+                "_text": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "de",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Hauptbeschwerde",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "fr",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Motif de consultation",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "en",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Chief complaint",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                  ],
+                },
+                "item": [
+                  {
+                    "_text": {
+                      "extension": [
+                        {
+                          "extension": [
+                            {
+                              "url": "lang",
+                              "valueCode": "fr",
+                            },
+                            {
+                              "url": "content",
+                              "valueString": "Détails",
+                            },
+                          ],
+                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        },
+                        {
+                          "extension": [
+                            {
+                              "url": "lang",
+                              "valueCode": "en",
+                            },
+                            {
+                              "url": "content",
+                              "valueString": "Details",
+                            },
+                          ],
+                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        },
+                      ],
+                    },
+                    "linkId": "details",
+                    "text": "Détails",
+                    "type": "string",
+                  },
+                ],
+                "linkId": "chief-complaint",
+                "text": "Motif de consultation",
+                "type": "string",
+              },
+            ],
+            "language": "fr",
+            "resourceType": "Questionnaire",
+            "status": "active",
+            "title": "Formulaire de motif de consultation",
+          }
+        `);
     });
 
     test('translates Questionnaire.title', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'de');
 
-        expect(result.title).toBe('Formular für Hauptbeschwerde');
-        expect(result._title).toBeUndefined();
-        expect(result.item?.[0]?.text).toBe('Hauptbeschwerde');
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "_title": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formular für Hauptbeschwerde",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "fr",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formulaire de motif de consultation",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "en",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Chief complaint form",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+              ],
+            },
+            "item": [
+              {
+                "_text": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "de",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Hauptbeschwerde",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "fr",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Motif de consultation",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "en",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Chief complaint",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                  ],
+                },
+                "item": [
+                  {
+                    "_text": {
+                      "extension": [
+                        {
+                          "extension": [
+                            {
+                              "url": "lang",
+                              "valueCode": "fr",
+                            },
+                            {
+                              "url": "content",
+                              "valueString": "Détails",
+                            },
+                          ],
+                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        },
+                      ],
+                    },
+                    "linkId": "details",
+                    "text": "Details",
+                    "type": "string",
+                  },
+                ],
+                "linkId": "chief-complaint",
+                "text": "Hauptbeschwerde",
+                "type": "string",
+              },
+            ],
+            "language": "de",
+            "resourceType": "Questionnaire",
+            "status": "active",
+            "title": "Formular für Hauptbeschwerde",
+          }
+        `);
     });
 
-    test('keeps original value when language is missing and strips translation extensions', () => {
+    test('keeps original value and translation extensions when language is missing', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'es');
 
-        expect(result.title).toBe('Chief complaint form');
-        expect(result._title).toBeUndefined();
-        expect(result.item?.[0]?.text).toBe('Chief complaint');
-        expect(result.item?.[0]?._text).toBeUndefined();
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "_title": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formular für Hauptbeschwerde",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "fr",
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Formulaire de motif de consultation",
+                    },
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                },
+              ],
+            },
+            "item": [
+              {
+                "_text": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "de",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Hauptbeschwerde",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "fr",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Motif de consultation",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                  ],
+                },
+                "item": [
+                  {
+                    "_text": {
+                      "extension": [
+                        {
+                          "extension": [
+                            {
+                              "url": "lang",
+                              "valueCode": "fr",
+                            },
+                            {
+                              "url": "content",
+                              "valueString": "Détails",
+                            },
+                          ],
+                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        },
+                      ],
+                    },
+                    "linkId": "details",
+                    "text": "Details",
+                    "type": "string",
+                  },
+                ],
+                "linkId": "chief-complaint",
+                "text": "Chief complaint",
+                "type": "string",
+              },
+            ],
+            "resourceType": "Questionnaire",
+            "status": "active",
+            "title": "Chief complaint form",
+          }
+        `);
     });
 
     test('preserves unrelated extensions on the same primitive element', () => {
@@ -136,18 +482,96 @@ describe('translateQuestionnaire', () => {
 
         const result = translateQuestionnaire(questionnaire, 'fr');
 
-        expect(result.item?.[0]?.text).toBe('Libellé');
-        expect(result.item?.[0]?._text).toEqual({
-            extension: [
-                {
-                    url: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
-                    valueExpression: {
-                        language: 'text/fhirpath',
-                        expression: "'Computed'",
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "item": [
+              {
+                "_text": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                      "valueExpression": {
+                        "expression": "'Computed'",
+                        "language": "text/fhirpath",
+                      },
                     },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "fr",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Libellé",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "en",
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Default label",
+                        },
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                    },
+                  ],
                 },
+                "linkId": "input-1",
+                "text": "Libellé",
+                "type": "string",
+              },
             ],
-        });
+            "language": "fr",
+            "resourceType": "Questionnaire",
+            "status": "active",
+          }
+        `);
+    });
+
+    test('stashes original under Questionnaire.language when present', () => {
+        const questionnaire: FHIRQuestionnaire = {
+            ...cloneDeep(translationQuestionnaire),
+            language: 'en-US',
+        };
+
+        const result = translateQuestionnaire(questionnaire, 'fr');
+
+        expect(result.language).toBe('fr');
+        expect(result._title?.extension).toEqual(
+            expect.arrayContaining([
+                {
+                    url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                    extension: [
+                        { url: 'lang', valueCode: 'en-US' },
+                        { url: 'content', valueString: 'Chief complaint form' },
+                    ],
+                },
+            ]),
+        );
+        expect(result.item?.[0]._text?.extension).toEqual(
+            expect.arrayContaining([
+                {
+                    url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                    extension: [
+                        { url: 'lang', valueCode: 'en-US' },
+                        { url: 'content', valueString: 'Chief complaint' },
+                    ],
+                },
+            ]),
+        );
+    });
+
+    test('leaves questionnaires without translations unchanged', () => {
+        const result = translateQuestionnaire(fhir_gad_7 as FHIRQuestionnaire, 'fr');
+
+        expect(result).toStrictEqual(fhir_gad_7);
     });
 
     test('does not mutate the input questionnaire', () => {

--- a/src/converter/__tests__/translateQuestionnaire.test.ts
+++ b/src/converter/__tests__/translateQuestionnaire.test.ts
@@ -1,0 +1,159 @@
+import { Questionnaire as FHIRQuestionnaire } from 'fhir/r4b';
+import { describe, expect, test } from 'vitest';
+import cloneDeep from 'lodash/cloneDeep';
+
+import { translateQuestionnaire } from '../fhirToFce/translateQuestionnaire';
+
+const translationQuestionnaire: FHIRQuestionnaire = {
+    resourceType: 'Questionnaire',
+    status: 'active',
+    title: 'Chief complaint form',
+    _title: {
+        extension: [
+            {
+                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                extension: [
+                    { url: 'lang', valueCode: 'de' },
+                    { url: 'content', valueString: 'Formular für Hauptbeschwerde' },
+                ],
+            },
+            {
+                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                extension: [
+                    { url: 'lang', valueCode: 'fr' },
+                    { url: 'content', valueString: 'Formulaire de motif de consultation' },
+                ],
+            },
+        ],
+    },
+    item: [
+        {
+            linkId: 'chief-complaint',
+            type: 'string',
+            text: 'Chief complaint',
+            _text: {
+                extension: [
+                    {
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'de' },
+                            { url: 'content', valueString: 'Hauptbeschwerde' },
+                        ],
+                    },
+                    {
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'fr' },
+                            { url: 'content', valueString: 'Motif de consultation' },
+                        ],
+                    },
+                ],
+            },
+            item: [
+                {
+                    linkId: 'details',
+                    type: 'string',
+                    text: 'Details',
+                    _text: {
+                        extension: [
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'fr' },
+                                    { url: 'content', valueString: 'Détails' },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+describe('translateQuestionnaire', () => {
+    test('translates item.text for the requested language', () => {
+        const result = translateQuestionnaire(translationQuestionnaire, 'fr');
+
+        expect(result.item?.[0]?.text).toBe('Motif de consultation');
+        expect(result.item?.[0]?._text).toBeUndefined();
+    });
+
+    test('translates nested item.text', () => {
+        const result = translateQuestionnaire(translationQuestionnaire, 'fr');
+
+        expect(result.item?.[0]?.item?.[0]?.text).toBe('Détails');
+        expect(result.item?.[0]?.item?.[0]?._text).toBeUndefined();
+    });
+
+    test('translates Questionnaire.title', () => {
+        const result = translateQuestionnaire(translationQuestionnaire, 'de');
+
+        expect(result.title).toBe('Formular für Hauptbeschwerde');
+        expect(result._title).toBeUndefined();
+        expect(result.item?.[0]?.text).toBe('Hauptbeschwerde');
+    });
+
+    test('keeps original value when language is missing and strips translation extensions', () => {
+        const result = translateQuestionnaire(translationQuestionnaire, 'es');
+
+        expect(result.title).toBe('Chief complaint form');
+        expect(result._title).toBeUndefined();
+        expect(result.item?.[0]?.text).toBe('Chief complaint');
+        expect(result.item?.[0]?._text).toBeUndefined();
+    });
+
+    test('preserves unrelated extensions on the same primitive element', () => {
+        const questionnaire: FHIRQuestionnaire = {
+            resourceType: 'Questionnaire',
+            status: 'active',
+            item: [
+                {
+                    linkId: 'input-1',
+                    type: 'string',
+                    text: 'Default label',
+                    _text: {
+                        extension: [
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
+                                valueExpression: {
+                                    language: 'text/fhirpath',
+                                    expression: "'Computed'",
+                                },
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'fr' },
+                                    { url: 'content', valueString: 'Libellé' },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        };
+
+        const result = translateQuestionnaire(questionnaire, 'fr');
+
+        expect(result.item?.[0]?.text).toBe('Libellé');
+        expect(result.item?.[0]?._text).toEqual({
+            extension: [
+                {
+                    url: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
+                    valueExpression: {
+                        language: 'text/fhirpath',
+                        expression: "'Computed'",
+                    },
+                },
+            ],
+        });
+    });
+
+    test('does not mutate the input questionnaire', () => {
+        const original = cloneDeep(translationQuestionnaire);
+        translateQuestionnaire(translationQuestionnaire, 'fr');
+
+        expect(translationQuestionnaire).toStrictEqual(original);
+    });
+});

--- a/src/converter/__tests__/translateQuestionnaire.test.ts
+++ b/src/converter/__tests__/translateQuestionnaire.test.ts
@@ -76,377 +76,190 @@ describe('translateQuestionnaire', () => {
     test('translates item.text and nested item.text for the requested language', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'fr');
 
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "_title": {
-              "extension": [
-                {
-                  "extension": [
+        const expected: FHIRQuestionnaire = {
+            resourceType: 'Questionnaire',
+            status: 'active',
+            language: 'fr',
+            title: 'Formulaire de motif de consultation',
+            _title: {
+                extension: [
                     {
-                      "url": "lang",
-                      "valueCode": "de",
-                    },
-                    {
-                      "url": "content",
-                      "valueString": "Formular für Hauptbeschwerde",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "fr",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'de' },
+                            { url: 'content', valueString: 'Formular für Hauptbeschwerde' },
+                        ],
                     },
                     {
-                      "url": "content",
-                      "valueString": "Formulaire de motif de consultation",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "en",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'fr' },
+                            { url: 'content', valueString: 'Formulaire de motif de consultation' },
+                        ],
                     },
                     {
-                      "url": "content",
-                      "valueString": "Chief complaint form",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'en' },
+                            { url: 'content', valueString: 'Chief complaint form' },
+                        ],
                     },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-              ],
-            },
-            "item": [
-              {
-                "_text": {
-                  "extension": [
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "de",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Hauptbeschwerde",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "fr",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Motif de consultation",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "en",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Chief complaint",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                  ],
-                },
-                "item": [
-                  {
-                    "_text": {
-                      "extension": [
-                        {
-                          "extension": [
-                            {
-                              "url": "lang",
-                              "valueCode": "fr",
-                            },
-                            {
-                              "url": "content",
-                              "valueString": "Détails",
-                            },
-                          ],
-                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                        },
-                        {
-                          "extension": [
-                            {
-                              "url": "lang",
-                              "valueCode": "en",
-                            },
-                            {
-                              "url": "content",
-                              "valueString": "Details",
-                            },
-                          ],
-                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                        },
-                      ],
-                    },
-                    "linkId": "details",
-                    "text": "Détails",
-                    "type": "string",
-                  },
                 ],
-                "linkId": "chief-complaint",
-                "text": "Motif de consultation",
-                "type": "string",
-              },
+            },
+            item: [
+                {
+                    linkId: 'chief-complaint',
+                    type: 'string',
+                    text: 'Motif de consultation',
+                    _text: {
+                        extension: [
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'de' },
+                                    { url: 'content', valueString: 'Hauptbeschwerde' },
+                                ],
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'fr' },
+                                    { url: 'content', valueString: 'Motif de consultation' },
+                                ],
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'en' },
+                                    { url: 'content', valueString: 'Chief complaint' },
+                                ],
+                            },
+                        ],
+                    },
+                    item: [
+                        {
+                            linkId: 'details',
+                            type: 'string',
+                            text: 'Détails',
+                            _text: {
+                                extension: [
+                                    {
+                                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                        extension: [
+                                            { url: 'lang', valueCode: 'fr' },
+                                            { url: 'content', valueString: 'Détails' },
+                                        ],
+                                    },
+                                    {
+                                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                        extension: [
+                                            { url: 'lang', valueCode: 'en' },
+                                            { url: 'content', valueString: 'Details' },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
             ],
-            "language": "fr",
-            "resourceType": "Questionnaire",
-            "status": "active",
-            "title": "Formulaire de motif de consultation",
-          }
-        `);
+        };
+
+        expect(result).toEqual(expected);
     });
 
     test('translates Questionnaire.title', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'de');
 
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "_title": {
-              "extension": [
-                {
-                  "extension": [
+        const expected: FHIRQuestionnaire = {
+            resourceType: 'Questionnaire',
+            status: 'active',
+            language: 'de',
+            title: 'Formular für Hauptbeschwerde',
+            _title: {
+                extension: [
                     {
-                      "url": "lang",
-                      "valueCode": "de",
-                    },
-                    {
-                      "url": "content",
-                      "valueString": "Formular für Hauptbeschwerde",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "fr",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'de' },
+                            { url: 'content', valueString: 'Formular für Hauptbeschwerde' },
+                        ],
                     },
                     {
-                      "url": "content",
-                      "valueString": "Formulaire de motif de consultation",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "en",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'fr' },
+                            { url: 'content', valueString: 'Formulaire de motif de consultation' },
+                        ],
                     },
                     {
-                      "url": "content",
-                      "valueString": "Chief complaint form",
+                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                        extension: [
+                            { url: 'lang', valueCode: 'en' },
+                            { url: 'content', valueString: 'Chief complaint form' },
+                        ],
                     },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-              ],
-            },
-            "item": [
-              {
-                "_text": {
-                  "extension": [
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "de",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Hauptbeschwerde",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "fr",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Motif de consultation",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "en",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Chief complaint",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                  ],
-                },
-                "item": [
-                  {
-                    "_text": {
-                      "extension": [
-                        {
-                          "extension": [
-                            {
-                              "url": "lang",
-                              "valueCode": "fr",
-                            },
-                            {
-                              "url": "content",
-                              "valueString": "Détails",
-                            },
-                          ],
-                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                        },
-                      ],
-                    },
-                    "linkId": "details",
-                    "text": "Details",
-                    "type": "string",
-                  },
                 ],
-                "linkId": "chief-complaint",
-                "text": "Hauptbeschwerde",
-                "type": "string",
-              },
+            },
+            item: [
+                {
+                    linkId: 'chief-complaint',
+                    type: 'string',
+                    text: 'Hauptbeschwerde',
+                    _text: {
+                        extension: [
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'de' },
+                                    { url: 'content', valueString: 'Hauptbeschwerde' },
+                                ],
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'fr' },
+                                    { url: 'content', valueString: 'Motif de consultation' },
+                                ],
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'en' },
+                                    { url: 'content', valueString: 'Chief complaint' },
+                                ],
+                            },
+                        ],
+                    },
+                    item: [
+                        {
+                            linkId: 'details',
+                            type: 'string',
+                            text: 'Details',
+                            _text: {
+                                extension: [
+                                    {
+                                        url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                        extension: [
+                                            { url: 'lang', valueCode: 'fr' },
+                                            { url: 'content', valueString: 'Détails' },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
             ],
-            "language": "de",
-            "resourceType": "Questionnaire",
-            "status": "active",
-            "title": "Formular für Hauptbeschwerde",
-          }
-        `);
+        };
+
+        expect(result).toEqual(expected);
     });
 
     test('keeps original value and translation extensions when language is missing', () => {
         const result = translateQuestionnaire(translationQuestionnaire, 'es');
 
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "_title": {
-              "extension": [
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "de",
-                    },
-                    {
-                      "url": "content",
-                      "valueString": "Formular für Hauptbeschwerde",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-                {
-                  "extension": [
-                    {
-                      "url": "lang",
-                      "valueCode": "fr",
-                    },
-                    {
-                      "url": "content",
-                      "valueString": "Formulaire de motif de consultation",
-                    },
-                  ],
-                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                },
-              ],
-            },
-            "item": [
-              {
-                "_text": {
-                  "extension": [
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "de",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Hauptbeschwerde",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "fr",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Motif de consultation",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                  ],
-                },
-                "item": [
-                  {
-                    "_text": {
-                      "extension": [
-                        {
-                          "extension": [
-                            {
-                              "url": "lang",
-                              "valueCode": "fr",
-                            },
-                            {
-                              "url": "content",
-                              "valueString": "Détails",
-                            },
-                          ],
-                          "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                        },
-                      ],
-                    },
-                    "linkId": "details",
-                    "text": "Details",
-                    "type": "string",
-                  },
-                ],
-                "linkId": "chief-complaint",
-                "text": "Chief complaint",
-                "type": "string",
-              },
-            ],
-            "resourceType": "Questionnaire",
-            "status": "active",
-            "title": "Chief complaint form",
-          }
-        `);
+        expect(result).toEqual(translationQuestionnaire);
     });
 
     test('preserves unrelated extensions on the same primitive element', () => {
@@ -482,57 +295,45 @@ describe('translateQuestionnaire', () => {
 
         const result = translateQuestionnaire(questionnaire, 'fr');
 
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "item": [
-              {
-                "_text": {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                      "valueExpression": {
-                        "expression": "'Computed'",
-                        "language": "text/fhirpath",
-                      },
+        const expected: FHIRQuestionnaire = {
+            resourceType: 'Questionnaire',
+            status: 'active',
+            language: 'fr',
+            item: [
+                {
+                    linkId: 'input-1',
+                    type: 'string',
+                    text: 'Libellé',
+                    _text: {
+                        extension: [
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
+                                valueExpression: {
+                                    language: 'text/fhirpath',
+                                    expression: "'Computed'",
+                                },
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'fr' },
+                                    { url: 'content', valueString: 'Libellé' },
+                                ],
+                            },
+                            {
+                                url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                                extension: [
+                                    { url: 'lang', valueCode: 'en' },
+                                    { url: 'content', valueString: 'Default label' },
+                                ],
+                            },
+                        ],
                     },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "fr",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Libellé",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                    {
-                      "extension": [
-                        {
-                          "url": "lang",
-                          "valueCode": "en",
-                        },
-                        {
-                          "url": "content",
-                          "valueString": "Default label",
-                        },
-                      ],
-                      "url": "http://hl7.org/fhir/StructureDefinition/translation",
-                    },
-                  ],
                 },
-                "linkId": "input-1",
-                "text": "Libellé",
-                "type": "string",
-              },
             ],
-            "language": "fr",
-            "resourceType": "Questionnaire",
-            "status": "active",
-          }
-        `);
+        };
+
+        expect(result).toEqual(expected);
     });
 
     test('stashes original under Questionnaire.language when present', () => {

--- a/src/converter/extensions.ts
+++ b/src/converter/extensions.ts
@@ -1,5 +1,9 @@
 import { Extension as FHIRExtension } from 'fhir/r4b';
-import { FCEQuestionnaireItem, FCEQuestionnaireItemAnswerOptionsToggleExpressionOption } from '../fce.types';
+import {
+    FCEQuestionnaireItem,
+    FCEQuestionnaireItemAnswerOptionsToggleExpressionOption,
+    FCETranslation,
+} from '../fce.types';
 
 export enum ExtensionIdentifier {
     Hidden = 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
@@ -60,6 +64,7 @@ export enum ExtensionIdentifier {
     ChartYAxisRange = 'https://emr-core.beda.software/StructureDefinition/chartYAxisRange',
     ChartHighlight = 'https://emr-core.beda.software/StructureDefinition/chartHighlight',
     ColumnWidth = 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-width',
+    Translation = 'http://hl7.org/fhir/StructureDefinition/translation',
 }
 
 export type ExtensionTransformer = {
@@ -515,6 +520,41 @@ export const extensionTransformers: ExtensionTransformer = {
     },
     [ExtensionIdentifier.ColumnWidth]: {
         path: { extension: 'valueQuantity', questionnaire: 'columnWidth' },
+    },
+    [ExtensionIdentifier.Translation]: {
+        transform: {
+            fromExtensions: (extensions) =>
+                ({
+                    translation: extensions.map((extension) => {
+                        const translationExtension = extension.extension!;
+
+                        return {
+                            lang: translationExtension.find((obj) => obj.url === 'lang')!.valueCode!,
+                            content: translationExtension.find((obj) => obj.url === 'content')!.valueString!,
+                        };
+                    }),
+                }) as Partial<FCEQuestionnaireItem>,
+            toExtensions: (item) => {
+                const translation = (item as FCEQuestionnaireItem & { translation?: FCETranslation[] }).translation;
+                if (translation) {
+                    return translation.map((entry) => ({
+                        url: ExtensionIdentifier.Translation,
+                        extension: [
+                            {
+                                url: 'lang',
+                                valueCode: entry.lang,
+                            },
+                            {
+                                url: 'content',
+                                valueString: entry.content,
+                            },
+                        ],
+                    }));
+                }
+
+                return [];
+            },
+        },
     },
 };
 

--- a/src/converter/fceToFhir/questionnaire/index.ts
+++ b/src/converter/fceToFhir/questionnaire/index.ts
@@ -3,10 +3,14 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { processExtensions } from './processExtensions';
 import { processItems } from './processItems';
+import { processPrimitiveExtensions } from '../utils';
 import { FCEQuestionnaire } from '../../../fce.types';
 
 export function convertQuestionnaire(questionnaire: FCEQuestionnaire): FHIRQuestionnaire {
     questionnaire = cloneDeep(questionnaire);
     questionnaire.item = processItems(questionnaire.item ?? []);
-    return processExtensions(questionnaire);
+    return {
+        ...processExtensions(questionnaire),
+        ...processPrimitiveExtensions(questionnaire),
+    };
 }

--- a/src/converter/fceToFhir/questionnaire/processItems.ts
+++ b/src/converter/fceToFhir/questionnaire/processItems.ts
@@ -2,6 +2,7 @@ import { QuestionnaireItem as FHIRQuestionnaireItem } from 'fhir/r4b';
 import _ from 'lodash';
 
 import { convertFromFHIRExtension, convertToFHIRExtension } from '../..';
+import { processPrimitiveExtensions } from '../utils';
 import { FCEQuestionnaireItem } from '../../../fce.types';
 
 export function processItems(items: FCEQuestionnaireItem[]): FHIRQuestionnaireItem[] {
@@ -24,20 +25,8 @@ export function processItems(items: FCEQuestionnaireItem[]): FHIRQuestionnaireIt
         const fhirItem: FHIRQuestionnaireItem = {
             ...commonOptions,
             type: type,
+            ...processPrimitiveExtensions(item),
         };
-
-        for (const property of Object.keys(item)) {
-            const element = item[property as keyof FCEQuestionnaireItem];
-
-            if (property.startsWith('_') && element instanceof Object) {
-                //@ts-expect-error: Element implicitly has an 'any' type
-                fhirItem[property] = {
-                    // TODO: update convertToFHIRExtension to accept element type to convert
-                    //@ts-expect-error: Argument of type is not assignable to parameter of type 'QuestionnaireItem'
-                    extension: convertToFHIRExtension(element),
-                };
-            }
-        }
 
         if (answerOption !== undefined) {
             fhirItem.answerOption = answerOption;

--- a/src/converter/fceToFhir/utils.ts
+++ b/src/converter/fceToFhir/utils.ts
@@ -1,0 +1,18 @@
+import { convertToFHIRExtension } from '..';
+
+export function processPrimitiveExtensions(element: Record<string, any>): Record<string, any> {
+    const result: Record<string, any> = {};
+
+    for (const property of Object.keys(element)) {
+        const value = element[property];
+
+        if (property.startsWith('_') && value instanceof Object && !Array.isArray(value)) {
+            result[property] = {
+                // TODO: update convertToFHIRExtension to accept element type to convert
+                extension: convertToFHIRExtension(value),
+            };
+        }
+    }
+
+    return result;
+}

--- a/src/converter/fhirToFce/index.ts
+++ b/src/converter/fhirToFce/index.ts
@@ -3,6 +3,8 @@ import { FCEQuestionnaire } from '../../fce.types';
 
 import { convertQuestionnaire } from './questionnaire';
 
+export { translateQuestionnaire } from './translateQuestionnaire';
+
 export function toFirstClassExtension(fhirResource: FHIRQuestionnaire): FCEQuestionnaire {
     return convertQuestionnaire(fhirResource);
 }

--- a/src/converter/fhirToFce/questionnaire/index.ts
+++ b/src/converter/fhirToFce/questionnaire/index.ts
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { processExtensions } from './processExtensions';
 import { processItems } from './processItems';
-import { checkFhirQuestionnaireProfile, trimUndefined } from '../utils';
+import { checkFhirQuestionnaireProfile, processPrimitiveExtensions, trimUndefined } from '../utils';
 import { FCEQuestionnaire } from '../../../fce.types';
 
 export function convertQuestionnaire(fhirQuestionnaire: FHIRQuestionnaire): FCEQuestionnaire {
@@ -12,7 +12,7 @@ export function convertQuestionnaire(fhirQuestionnaire: FHIRQuestionnaire): FCEQ
     const item = processItems(fhirQuestionnaire);
     const extensions = processExtensions(fhirQuestionnaire);
     const questionnaire = trimUndefined({
-        ...fhirQuestionnaire,
+        ...processPrimitiveExtensions(fhirQuestionnaire),
         item,
         ...extensions,
         extension: undefined,

--- a/src/converter/fhirToFce/questionnaire/processItems.ts
+++ b/src/converter/fhirToFce/questionnaire/processItems.ts
@@ -1,7 +1,6 @@
-import { Questionnaire as FHIRQuestionnaire, QuestionnaireItem as FHIRQuestionnaireItem, Extension } from 'fhir/r4b';
+import { Questionnaire as FHIRQuestionnaire, QuestionnaireItem as FHIRQuestionnaireItem } from 'fhir/r4b';
 
-import { convertFromFHIRExtension } from '../..';
-import { ExtensionIdentifier } from '../../extensions';
+import { processExtensibleElement, processPrimitiveExtensions } from '../utils';
 import { FCEQuestionnaireItem } from '../../../fce.types';
 
 export function processItems(fhirQuestionnaire: FHIRQuestionnaire) {
@@ -18,49 +17,5 @@ function convertItemProperties(item: FHIRQuestionnaireItem): FCEQuestionnaireIte
 }
 
 function getUpdatedPropertiesFromItem(item: FHIRQuestionnaireItem) {
-    let newItem: FCEQuestionnaireItem = { ...item };
-
-    // Primitive extensions
-    for (const property of Object.keys(item)) {
-        const element = item[property as keyof FHIRQuestionnaireItem];
-        if (property.startsWith('_') && element instanceof Object && !Array.isArray(element)) {
-            newItem = {
-                ...newItem,
-                ...{
-                    [property]: processExtensibleElement(element),
-                },
-            };
-        }
-    }
-
-    return processExtensibleElement(newItem);
-}
-
-function processExtensibleElement<T extends { extension?: Extension[] }>(element: T): T {
-    let newElement = { ...element };
-    const knownExtensionUrls = Object.values(ExtensionIdentifier) as string[];
-
-    const allExtensions = element.extension ?? [];
-    const knownExtensions = allExtensions.filter((ext) => knownExtensionUrls.includes(ext.url));
-    const unknownExtensions = allExtensions.filter((ext) => !knownExtensionUrls.includes(ext.url));
-
-    if (knownExtensions.length) {
-        const uniqueExtensionUrls = new Set(knownExtensions.map((ext) => ext.url));
-        for (const extensionUrl of uniqueExtensionUrls) {
-            const extensions = knownExtensions.filter((ext) => ext.url === extensionUrl);
-
-            newElement = {
-                ...newElement,
-                ...convertFromFHIRExtension(extensions),
-            };
-        }
-    }
-
-    if (unknownExtensions.length) {
-        newElement.extension = unknownExtensions;
-    } else {
-        delete newElement.extension;
-    }
-
-    return newElement;
+    return processExtensibleElement(processPrimitiveExtensions({ ...item }));
 }

--- a/src/converter/fhirToFce/translateQuestionnaire.ts
+++ b/src/converter/fhirToFce/translateQuestionnaire.ts
@@ -6,27 +6,26 @@ import { ExtensionIdentifier } from '../extensions';
 export function translateQuestionnaire(questionnaire: FHIRQuestionnaire, language: string): FHIRQuestionnaire {
     const result = cloneDeep(questionnaire);
     const originLang = result.language ?? 'en';
-    const applied = { value: false };
 
-    translateNode(result, language, originLang, applied);
-
-    if (applied.value) {
+    if (translateNode(result, language, originLang)) {
         result.language = language;
     }
 
     return result;
 }
 
-function translateNode(node: unknown, language: string, originLang: string, applied: { value: boolean }): void {
+function translateNode(node: unknown, language: string, originLang: string): boolean {
     if (node === null || typeof node !== 'object') {
-        return;
+        return false;
     }
+
+    let applied = false;
 
     if (Array.isArray(node)) {
         for (const item of node) {
-            translateNode(item, language, originLang, applied);
+            applied = translateNode(item, language, originLang) || applied;
         }
-        return;
+        return applied;
     }
 
     const object = node as Record<string, unknown>;
@@ -35,14 +34,16 @@ function translateNode(node: unknown, language: string, originLang: string, appl
         if (property.startsWith('_')) {
             const element = object[property];
             if (element instanceof Object && !Array.isArray(element)) {
-                applyTranslation(object, property, element as Element, language, originLang, applied);
+                applied = applyTranslation(object, property, element as Element, language, originLang) || applied;
             }
         }
     }
 
     for (const value of Object.values(object)) {
-        translateNode(value, language, originLang, applied);
+        applied = translateNode(value, language, originLang) || applied;
     }
+
+    return applied;
 }
 
 function applyTranslation(
@@ -51,16 +52,15 @@ function applyTranslation(
     element: Element,
     language: string,
     originLang: string,
-    applied: { value: boolean },
-): void {
+): boolean {
     const extensions = element.extension;
     if (!extensions?.length) {
-        return;
+        return false;
     }
 
     const translationExtensions = extensions.filter((ext) => ext.url === ExtensionIdentifier.Translation);
     if (!translationExtensions.length) {
-        return;
+        return false;
     }
 
     const matchedTranslation = translationExtensions.find((ext) => {
@@ -69,19 +69,19 @@ function applyTranslation(
     });
 
     if (!matchedTranslation) {
-        return;
+        return false;
     }
 
     const contentExtension = matchedTranslation.extension?.find((sub) => sub.url === 'content');
     if (!contentExtension) {
-        return;
+        return false;
     }
 
     const valueKey = Object.keys(contentExtension).find((key) => key.startsWith('value')) as
         | keyof Extension
         | undefined;
     if (!valueKey) {
-        return;
+        return false;
     }
 
     const primitiveProperty = underscoreProperty.slice(1);
@@ -92,7 +92,7 @@ function applyTranslation(
     }
 
     parent[primitiveProperty] = contentExtension[valueKey];
-    applied.value = true;
+    return true;
 }
 
 function upsertOriginalTranslation(extensions: Extension[], originLang: string, originalValue: unknown): void {

--- a/src/converter/fhirToFce/translateQuestionnaire.ts
+++ b/src/converter/fhirToFce/translateQuestionnaire.ts
@@ -1,0 +1,84 @@
+import { Element, Extension, Questionnaire as FHIRQuestionnaire } from 'fhir/r4b';
+import cloneDeep from 'lodash/cloneDeep';
+
+import { ExtensionIdentifier } from '../extensions';
+
+export function translateQuestionnaire(questionnaire: FHIRQuestionnaire, language: string): FHIRQuestionnaire {
+    const result = cloneDeep(questionnaire);
+    translateNode(result, language);
+    return result;
+}
+
+function translateNode(node: unknown, language: string): void {
+    if (node === null || typeof node !== 'object') {
+        return;
+    }
+
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            translateNode(item, language);
+        }
+        return;
+    }
+
+    const object = node as Record<string, unknown>;
+
+    for (const property of Object.keys(object)) {
+        if (property.startsWith('_')) {
+            const element = object[property];
+            if (element instanceof Object && !Array.isArray(element)) {
+                applyTranslation(object, property, element as Element, language);
+            }
+        }
+    }
+
+    for (const value of Object.values(object)) {
+        translateNode(value, language);
+    }
+}
+
+function applyTranslation(
+    parent: Record<string, unknown>,
+    underscoreProperty: string,
+    element: Element,
+    language: string,
+): void {
+    const extensions = element.extension;
+    if (!extensions?.length) {
+        return;
+    }
+
+    const translationExtensions = extensions.filter((ext) => ext.url === ExtensionIdentifier.Translation);
+    if (!translationExtensions.length) {
+        return;
+    }
+
+    const matchedTranslation = translationExtensions.find((ext) => {
+        const lang = ext.extension?.find((sub) => sub.url === 'lang')?.valueCode;
+        return lang === language;
+    });
+
+    if (matchedTranslation) {
+        const contentExtension = matchedTranslation.extension?.find((sub) => sub.url === 'content');
+        if (contentExtension) {
+            const valueKey = Object.keys(contentExtension).find((key) => key.startsWith('value')) as
+                | keyof Extension
+                | undefined;
+            if (valueKey) {
+                const primitiveProperty = underscoreProperty.slice(1);
+                parent[primitiveProperty] = contentExtension[valueKey];
+            }
+        }
+    }
+
+    const remainingExtensions = extensions.filter((ext) => ext.url !== ExtensionIdentifier.Translation);
+    if (remainingExtensions.length) {
+        element.extension = remainingExtensions;
+    } else {
+        delete element.extension;
+    }
+
+    if (Object.keys(element).length === 0) {
+        delete parent[underscoreProperty];
+    }
+}

--- a/src/converter/fhirToFce/translateQuestionnaire.ts
+++ b/src/converter/fhirToFce/translateQuestionnaire.ts
@@ -5,18 +5,26 @@ import { ExtensionIdentifier } from '../extensions';
 
 export function translateQuestionnaire(questionnaire: FHIRQuestionnaire, language: string): FHIRQuestionnaire {
     const result = cloneDeep(questionnaire);
-    translateNode(result, language);
+    const originLang = result.language ?? 'en';
+    const applied = { value: false };
+
+    translateNode(result, language, originLang, applied);
+
+    if (applied.value) {
+        result.language = language;
+    }
+
     return result;
 }
 
-function translateNode(node: unknown, language: string): void {
+function translateNode(node: unknown, language: string, originLang: string, applied: { value: boolean }): void {
     if (node === null || typeof node !== 'object') {
         return;
     }
 
     if (Array.isArray(node)) {
         for (const item of node) {
-            translateNode(item, language);
+            translateNode(item, language, originLang, applied);
         }
         return;
     }
@@ -27,13 +35,13 @@ function translateNode(node: unknown, language: string): void {
         if (property.startsWith('_')) {
             const element = object[property];
             if (element instanceof Object && !Array.isArray(element)) {
-                applyTranslation(object, property, element as Element, language);
+                applyTranslation(object, property, element as Element, language, originLang, applied);
             }
         }
     }
 
     for (const value of Object.values(object)) {
-        translateNode(value, language);
+        translateNode(value, language, originLang, applied);
     }
 }
 
@@ -42,6 +50,8 @@ function applyTranslation(
     underscoreProperty: string,
     element: Element,
     language: string,
+    originLang: string,
+    applied: { value: boolean },
 ): void {
     const extensions = element.extension;
     if (!extensions?.length) {
@@ -58,27 +68,65 @@ function applyTranslation(
         return lang === language;
     });
 
-    if (matchedTranslation) {
-        const contentExtension = matchedTranslation.extension?.find((sub) => sub.url === 'content');
+    if (!matchedTranslation) {
+        return;
+    }
+
+    const contentExtension = matchedTranslation.extension?.find((sub) => sub.url === 'content');
+    if (!contentExtension) {
+        return;
+    }
+
+    const valueKey = Object.keys(contentExtension).find((key) => key.startsWith('value')) as
+        | keyof Extension
+        | undefined;
+    if (!valueKey) {
+        return;
+    }
+
+    const primitiveProperty = underscoreProperty.slice(1);
+    const originalValue = parent[primitiveProperty];
+
+    if (originalValue !== undefined && originalValue !== null) {
+        upsertOriginalTranslation(extensions, originLang, originalValue);
+    }
+
+    parent[primitiveProperty] = contentExtension[valueKey];
+    applied.value = true;
+}
+
+function upsertOriginalTranslation(extensions: Extension[], originLang: string, originalValue: unknown): void {
+    const existing = extensions.find((ext) => {
+        if (ext.url !== ExtensionIdentifier.Translation) {
+            return false;
+        }
+        const lang = ext.extension?.find((sub) => sub.url === 'lang')?.valueCode;
+        return lang === originLang;
+    });
+
+    if (existing) {
+        const contentExtension = existing.extension?.find((sub) => sub.url === 'content');
         if (contentExtension) {
             const valueKey = Object.keys(contentExtension).find((key) => key.startsWith('value')) as
                 | keyof Extension
                 | undefined;
             if (valueKey) {
-                const primitiveProperty = underscoreProperty.slice(1);
-                parent[primitiveProperty] = contentExtension[valueKey];
+                (contentExtension as Extension)[valueKey] = originalValue as never;
+                return;
             }
         }
+        existing.extension = [
+            { url: 'lang', valueCode: originLang },
+            { url: 'content', valueString: String(originalValue) },
+        ];
+        return;
     }
 
-    const remainingExtensions = extensions.filter((ext) => ext.url !== ExtensionIdentifier.Translation);
-    if (remainingExtensions.length) {
-        element.extension = remainingExtensions;
-    } else {
-        delete element.extension;
-    }
-
-    if (Object.keys(element).length === 0) {
-        delete parent[underscoreProperty];
-    }
+    extensions.push({
+        url: ExtensionIdentifier.Translation,
+        extension: [
+            { url: 'lang', valueCode: originLang },
+            { url: 'content', valueString: String(originalValue) },
+        ],
+    });
 }

--- a/src/converter/fhirToFce/utils.ts
+++ b/src/converter/fhirToFce/utils.ts
@@ -1,4 +1,7 @@
-import { Questionnaire as FHIRQuestionnaire } from 'fhir/r4b';
+import { Extension, Questionnaire as FHIRQuestionnaire } from 'fhir/r4b';
+
+import { convertFromFHIRExtension } from '..';
+import { ExtensionIdentifier } from '../extensions';
 
 export function checkFhirQuestionnaireProfile(fhirQuestionnaire: FHIRQuestionnaire): void {
     if (
@@ -33,4 +36,49 @@ export function trimUndefined(e: any) {
     }
 
     return e;
+}
+
+export function processExtensibleElement<T extends { extension?: Extension[] }>(element: T): T {
+    let newElement = { ...element };
+    const knownExtensionUrls = Object.values(ExtensionIdentifier) as string[];
+
+    const allExtensions = element.extension ?? [];
+    const knownExtensions = allExtensions.filter((ext) => knownExtensionUrls.includes(ext.url));
+    const unknownExtensions = allExtensions.filter((ext) => !knownExtensionUrls.includes(ext.url));
+
+    if (knownExtensions.length) {
+        const uniqueExtensionUrls = new Set(knownExtensions.map((ext) => ext.url));
+        for (const extensionUrl of uniqueExtensionUrls) {
+            const extensions = knownExtensions.filter((ext) => ext.url === extensionUrl);
+
+            newElement = {
+                ...newElement,
+                ...convertFromFHIRExtension(extensions),
+            };
+        }
+    }
+
+    if (unknownExtensions.length) {
+        newElement.extension = unknownExtensions;
+    } else {
+        delete newElement.extension;
+    }
+
+    return newElement;
+}
+
+export function processPrimitiveExtensions<T extends Record<string, any>>(resource: T): T {
+    let result = { ...resource };
+
+    for (const property of Object.keys(resource)) {
+        const element = resource[property];
+        if (property.startsWith('_') && element instanceof Object && !Array.isArray(element)) {
+            result = {
+                ...result,
+                [property]: processExtensibleElement(element),
+            };
+        }
+    }
+
+    return result;
 }

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -2,7 +2,7 @@ import { Extension as FHIRExtension } from 'fhir/r4b';
 
 import { ExtensionIdentifier, extensionTransformers } from './extensions';
 import { fromFirstClassExtension } from './fceToFhir';
-import { toFirstClassExtension } from './fhirToFce';
+import { toFirstClassExtension, translateQuestionnaire } from './fhirToFce';
 import { processLaunchContext as processLaunchContextToFce } from './fhirToFce/questionnaire/processExtensions';
 import { FCEQuestionnaireItem } from '../fce.types';
 export * from './utils';
@@ -49,4 +49,4 @@ export function convertToFHIRExtension(item: FCEQuestionnaireItem): FHIRExtensio
     return extensions;
 }
 
-export { toFirstClassExtension, fromFirstClassExtension, processLaunchContextToFce };
+export { toFirstClassExtension, fromFirstClassExtension, translateQuestionnaire, processLaunchContextToFce };

--- a/src/fce.types.ts
+++ b/src/fce.types.ts
@@ -44,6 +44,8 @@ export interface FCEQuestionnaire extends Questionnaire {
     printableFooterLastPage?: FCEPrintableElement[];
     /** NOTE: from extension http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap */
     targetStructureMap?: string[];
+    /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/translation */
+    _title?: FCEQuestionnaireTitle;
 }
 
 export interface FCEQuestionnaireItem extends QuestionnaireItem {
@@ -135,8 +137,21 @@ export interface FCEQuestionnaireItem extends QuestionnaireItem {
     columnWidth?: Quantity;
 }
 
+export interface FCETranslation {
+    lang: string;
+    content: string;
+}
+
 export interface FCEQuestionnaireItemText {
     cqfExpression?: Expression;
+    /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/translation */
+    translation?: FCETranslation[];
+    extension?: Extension[];
+}
+
+export interface FCEQuestionnaireTitle {
+    /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/translation */
+    translation?: FCETranslation[];
     extension?: Extension[];
 }
 


### PR DESCRIPTION
- Add FHIR ↔ FCE support for the translation primitive extension on fields like Questionnaire.title and Questionnaire.item.text;
- Process primitive extensions at the Questionnaire root (not only items), so _title round-trips correctly;
- Add translateQuestionnaire(questionnaire, language) to bake a language into a FHIR Questionnaire before FCE conversion;
- Document the feature in the README.

Closes #56 #57 