### PR TITLE
Fix/recursive primitive extensions

### DIFF
--- a/src/converter/__tests__/resources/questionnaire_fce/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation.json
@@ -31,7 +31,81 @@
                         "content": "Motif de consultation"
                     }
                 ]
-            }
+            },
+            "initial": [
+                {
+                    "valueString": "Headache",
+                    "_valueString": {
+                        "translation": [
+                            {
+                                "lang": "de",
+                                "content": "Kopfschmerzen"
+                            },
+                            {
+                                "lang": "fr",
+                                "content": "Mal de tête"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "pain-level",
+            "type": "choice",
+            "text": "Pain level",
+            "_text": {
+                "translation": [
+                    {
+                        "lang": "de",
+                        "content": "Schmerzintensität"
+                    },
+                    {
+                        "lang": "fr",
+                        "content": "Niveau de douleur"
+                    }
+                ]
+            },
+            "answerOption": [
+                {
+                    "valueCoding": {
+                        "code": "mild",
+                        "system": "http://example.org/pain-level",
+                        "display": "Mild",
+                        "_display": {
+                            "translation": [
+                                {
+                                    "lang": "de",
+                                    "content": "Leicht"
+                                },
+                                {
+                                    "lang": "fr",
+                                    "content": "Léger"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "valueCoding": {
+                        "code": "severe",
+                        "system": "http://example.org/pain-level",
+                        "display": "Severe",
+                        "_display": {
+                            "translation": [
+                                {
+                                    "lang": "de",
+                                    "content": "Schwer"
+                                },
+                                {
+                                    "lang": "fr",
+                                    "content": "Sévère"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
     ],
     "meta": {

--- a/src/converter/__tests__/resources/questionnaire_fhir/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fhir/translation.json
@@ -67,7 +67,153 @@
                         ]
                     }
                 ]
-            }
+            },
+            "initial": [
+                {
+                    "valueString": "Headache",
+                    "_valueString": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Kopfschmerzen"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Mal de tête"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "pain-level",
+            "type": "choice",
+            "text": "Pain level",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Schmerzintensität"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Niveau de douleur"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "answerOption": [
+                {
+                    "valueCoding": {
+                        "code": "mild",
+                        "system": "http://example.org/pain-level",
+                        "display": "Mild",
+                        "_display": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "de"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Leicht"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "fr"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Léger"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "valueCoding": {
+                        "code": "severe",
+                        "system": "http://example.org/pain-level",
+                        "display": "Severe",
+                        "_display": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "de"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Schwer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "fr"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Sévère"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
     ],
     "meta": {

--- a/src/converter/fceToFhir/questionnaire/index.ts
+++ b/src/converter/fceToFhir/questionnaire/index.ts
@@ -8,9 +8,12 @@ import { FCEQuestionnaire } from '../../../fce.types';
 
 export function convertQuestionnaire(questionnaire: FCEQuestionnaire): FHIRQuestionnaire {
     questionnaire = cloneDeep(questionnaire);
-    questionnaire.item = processItems(questionnaire.item ?? []);
+    const processedItem = processItems(questionnaire.item ?? []);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { item: _item, ...rest } = questionnaire;
+
     return {
-        ...processExtensions(questionnaire),
-        ...processPrimitiveExtensions(questionnaire),
+        ...processPrimitiveExtensions(processExtensions(rest as FCEQuestionnaire)),
+        item: processedItem,
     };
 }

--- a/src/converter/fceToFhir/questionnaire/processItems.ts
+++ b/src/converter/fceToFhir/questionnaire/processItems.ts
@@ -20,29 +20,8 @@ export function processItems(items: FCEQuestionnaireItem[]): FHIRQuestionnaireIt
             item.extension = extensions.sort();
         }
 
-        const { enableBehavior, enableWhen, answerOption, initial, item: nestedItems, type, ...commonOptions } = item;
-
-        const fhirItem: FHIRQuestionnaireItem = {
-            ...commonOptions,
-            type: type,
-            ...processPrimitiveExtensions(item),
-        };
-
-        if (answerOption !== undefined) {
-            fhirItem.answerOption = answerOption;
-        }
-
-        if (enableBehavior !== undefined) {
-            fhirItem.enableBehavior = enableBehavior;
-        }
-
-        if (enableWhen !== undefined) {
-            fhirItem.enableWhen = enableWhen;
-        }
-
-        if (initial) {
-            fhirItem.initial = initial;
-        }
+        const { item: nestedItems, ...rest } = item;
+        const fhirItem = processPrimitiveExtensions(rest) as FHIRQuestionnaireItem;
 
         if (nestedItems) {
             fhirItem.item = processItems(nestedItems);

--- a/src/converter/fceToFhir/utils.ts
+++ b/src/converter/fceToFhir/utils.ts
@@ -1,18 +1,34 @@
 import { convertToFHIRExtension } from '..';
 
-export function processPrimitiveExtensions(element: Record<string, any>): Record<string, any> {
-    const result: Record<string, any> = {};
+export function processPrimitiveExtensions<T>(element: T): T {
+    walk(element);
+    return element;
+}
 
-    for (const property of Object.keys(element)) {
-        const value = element[property];
-
-        if (property.startsWith('_') && value instanceof Object && !Array.isArray(value)) {
-            result[property] = {
-                // TODO: update convertToFHIRExtension to accept element type to convert
-                extension: convertToFHIRExtension(value),
-            };
-        }
+function walk(node: unknown): void {
+    if (node === null || typeof node !== 'object') {
+        return;
     }
 
-    return result;
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            walk(item);
+        }
+        return;
+    }
+
+    const object = node as Record<string, unknown>;
+
+    for (const property of Object.keys(object)) {
+        const value = object[property];
+
+        if (property.startsWith('_') && value instanceof Object && !Array.isArray(value)) {
+            object[property] = {
+                // TODO: update convertToFHIRExtension to accept element type to convert
+                extension: convertToFHIRExtension(value as any),
+            };
+        } else {
+            walk(value);
+        }
+    }
 }

--- a/src/converter/fhirToFce/questionnaire/index.ts
+++ b/src/converter/fhirToFce/questionnaire/index.ts
@@ -9,11 +9,13 @@ import { FCEQuestionnaire } from '../../../fce.types';
 export function convertQuestionnaire(fhirQuestionnaire: FHIRQuestionnaire): FCEQuestionnaire {
     checkFhirQuestionnaireProfile(fhirQuestionnaire);
     fhirQuestionnaire = cloneDeep(fhirQuestionnaire);
-    const item = processItems(fhirQuestionnaire);
+    const processedItem = processItems(fhirQuestionnaire);
     const extensions = processExtensions(fhirQuestionnaire);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { item: _item, ...rest } = fhirQuestionnaire;
     const questionnaire = trimUndefined({
-        ...processPrimitiveExtensions(fhirQuestionnaire),
-        item,
+        ...processPrimitiveExtensions(rest),
+        item: processedItem,
         ...extensions,
         extension: undefined,
     });

--- a/src/converter/fhirToFce/questionnaire/processItems.ts
+++ b/src/converter/fhirToFce/questionnaire/processItems.ts
@@ -8,14 +8,12 @@ export function processItems(fhirQuestionnaire: FHIRQuestionnaire) {
 }
 
 function convertItemProperties(item: FHIRQuestionnaireItem): FCEQuestionnaireItem {
-    const newItem = getUpdatedPropertiesFromItem(item);
+    const { item: nestedItems, ...rest } = item;
+    const newItem = processExtensibleElement(processPrimitiveExtensions(rest)) as FCEQuestionnaireItem;
 
-    if (item.item) {
-        newItem.item = item.item.map((nestedItem) => convertItemProperties(nestedItem));
+    if (nestedItems) {
+        newItem.item = nestedItems.map((nestedItem) => convertItemProperties(nestedItem));
     }
-    return newItem;
-}
 
-function getUpdatedPropertiesFromItem(item: FHIRQuestionnaireItem) {
-    return processExtensibleElement(processPrimitiveExtensions({ ...item }));
+    return newItem;
 }

--- a/src/converter/fhirToFce/utils.ts
+++ b/src/converter/fhirToFce/utils.ts
@@ -67,18 +67,32 @@ export function processExtensibleElement<T extends { extension?: Extension[] }>(
     return newElement;
 }
 
-export function processPrimitiveExtensions<T extends Record<string, any>>(resource: T): T {
-    let result = { ...resource };
+export function processPrimitiveExtensions<T>(resource: T): T {
+    walk(resource);
+    return resource;
+}
 
-    for (const property of Object.keys(resource)) {
-        const element = resource[property];
-        if (property.startsWith('_') && element instanceof Object && !Array.isArray(element)) {
-            result = {
-                ...result,
-                [property]: processExtensibleElement(element),
-            };
-        }
+function walk(node: unknown): void {
+    if (node === null || typeof node !== 'object') {
+        return;
     }
 
-    return result;
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            walk(item);
+        }
+        return;
+    }
+
+    const object = node as Record<string, unknown>;
+
+    for (const property of Object.keys(object)) {
+        const value = object[property];
+
+        if (property.startsWith('_') && value instanceof Object && !Array.isArray(value)) {
+            object[property] = processExtensibleElement(value as { extension?: Extension[] });
+        } else {
+            walk(value);
+        }
+    }
 }


### PR DESCRIPTION
- Convert primitive extensions (_display, _text, _valueString, etc.) recursively anywhere in the questionnaire tree for both FCE→FHIR and FHIR→FCE
- Avoids copying nested structures like answerOption[].valueCoding._display and initial[]._valueString as-is
- Extends translation fixtures to cover those nested cases