### PR TITLE
Extend translation fixtures for helpText, entryFormat, and constraints

### DIFF
--- a/src/converter/__tests__/fce.test.ts
+++ b/src/converter/__tests__/fce.test.ts
@@ -38,6 +38,7 @@ import fce_practitioner_edit from './resources/questionnaire_fce/practitioner_ed
 import fce_practitioner_role_create from './resources/questionnaire_fce/practitioner_role_create.json';
 import fce_printable_elements from './resources/questionnaire_fce/printable_elements.json';
 import fce_translation from './resources/questionnaire_fce/translation.json';
+import fce_translation_mixed_extensions from './resources/questionnaire_fce/translation-mixed-extensions.json';
 import fce_public_appointment from './resources/questionnaire_fce/public_appointment.json';
 import fce_questionnaire_variable from './resources/questionnaire_fce/questionnaire_variable.json';
 import fce_review_of_systems from './resources/questionnaire_fce/review_of_systems.json';
@@ -85,6 +86,7 @@ import fhir_practitioner_edit from './resources/questionnaire_fhir/practitioner_
 import fhir_practitioner_role_create from './resources/questionnaire_fhir/practitioner_role_create.json';
 import fhir_printable_elements from './resources/questionnaire_fhir/printable_elements.json';
 import fhir_translation from './resources/questionnaire_fhir/translation.json';
+import fhir_translation_mixed_extensions from './resources/questionnaire_fhir/translation-mixed-extensions.json';
 import fhir_public_appointment from './resources/questionnaire_fhir/public_appointment.json';
 import fhir_questionnaire_variable from './resources/questionnaire_fhir/questionnaire_variable.json';
 import fhir_review_of_systems from './resources/questionnaire_fhir/review_of_systems.json';
@@ -153,6 +155,7 @@ describe('Questionanire and QuestionnaireResponses transformation', () => {
         ['mapping-inline', fhir_mapping_inline, fce_mapping_inline],
         ['printable-elements', fhir_printable_elements, fce_printable_elements],
         ['translation', fhir_translation, fce_translation],
+        ['translation-mixed-extensions', fhir_translation_mixed_extensions, fce_translation_mixed_extensions],
     ])('Each FHIR Questionnaire should convert to FCE %s', async (_, fhir_questionnaire, fce_questionnaire) => {
         expect(toFirstClassExtension(fhir_questionnaire as FHIRQuestionnaire)).toStrictEqual(fce_questionnaire);
     });
@@ -207,6 +210,7 @@ describe('Questionanire and QuestionnaireResponses transformation', () => {
         ['mapping-inline', fce_mapping_inline, fhir_mapping_inline],
         ['printable-elements', fce_printable_elements, fhir_printable_elements],
         ['translation', fce_translation, fhir_translation],
+        ['translation-mixed-extensions', fce_translation_mixed_extensions, fhir_translation_mixed_extensions],
     ])('Each FCE Questionnaire should convert to FHIR %s', async (_, fce_questionnaire, fhir_questionnaire) => {
         expect(sortExtensionsList(fromFirstClassExtension(fce_questionnaire as FCEQuestionnaire))).toStrictEqual(
             sortExtensionsList(fhir_questionnaire),

--- a/src/converter/__tests__/resources/questionnaire_fce/translation-mixed-extensions.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation-mixed-extensions.json
@@ -1,0 +1,38 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-mixed-extensions",
+    "status": "active",
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "helpText": "Chief complaint help text",
+            "_helpText": {
+                "translation": [
+                    {
+                        "lang": "de",
+                        "content": "Hauptbeschwerde Hilfe-Text"
+                    },
+                    {
+                        "lang": "fr",
+                        "content": "Texte d'aide du motif de consultation"
+                    }
+                ],
+                "cqfExpression": {
+                    "language": "text/fhirpath",
+                    "expression": "'Computed help text'"
+                },
+                "extension": [
+                    {
+                        "url": "urn:unknown-help-text-extension",
+                        "valueString": "Unknown extension on helpText"
+                    }
+                ]
+            }
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/__tests__/resources/questionnaire_fce/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation.json
@@ -32,6 +32,19 @@
                     }
                 ]
             },
+            "helpText": "Chief complaint help text",
+            "_helpText": {
+                "translation": [
+                    {
+                        "lang": "de",
+                        "content": "Hauptbeschwerde Hilfe-Text"
+                    },
+                    {
+                        "lang": "fr",
+                        "content": "Texte d'aide du motif de consultation"
+                    }
+                ]
+            },
             "initial": [
                 {
                     "valueString": "Headache",
@@ -53,6 +66,19 @@
         {
             "linkId": "pain-level",
             "type": "choice",
+            "entryFormat": "Choose the pain level",
+            "_entryFormat": {
+                "translation": [
+                    {
+                        "lang": "de",
+                        "content": "Wählen Sie die Schmerzintensität"
+                    },
+                    {
+                        "lang": "fr",
+                        "content": "Choisir le niveau de douleur"
+                    }
+                ]
+            },
             "text": "Pain level",
             "_text": {
                 "translation": [
@@ -104,6 +130,31 @@
                             ]
                         }
                     }
+                }
+            ]
+        },
+        {
+            "type": "string",
+            "linkId": "email",
+            "itemConstraint": [
+                {
+                    "key": "first",
+                    "requirements": "Lentgth must be less than 10 characters",
+                    "severity": "error",
+                    "human": "Length must be less than 10 characters",
+                    "_human": {
+                        "translation": [
+                            {
+                                "lang": "de",
+                                "content": "Länge muss weniger als 10 Zeichen sein"
+                            },
+                            {
+                                "lang": "fr",
+                                "content": "La longueur doit être inférieure à 10 caractères"
+                            }
+                        ]
+                    },
+                    "expression": "false"
                 }
             ]
         }

--- a/src/converter/__tests__/resources/questionnaire_fce/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation.json
@@ -139,7 +139,7 @@
             "itemConstraint": [
                 {
                     "key": "first",
-                    "requirements": "Lentgth must be less than 10 characters",
+                    "requirements": "Req first",
                     "severity": "error",
                     "human": "Length must be less than 10 characters",
                     "_human": {

--- a/src/converter/__tests__/resources/questionnaire_fhir/translation-mixed-extensions.json
+++ b/src/converter/__tests__/resources/questionnaire_fhir/translation-mixed-extensions.json
@@ -1,0 +1,62 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-mixed-extensions",
+    "status": "active",
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "extension": [
+                {
+                    "url": "https://emr-core.beda.software/StructureDefinition/help-text",
+                    "valueString": "Chief complaint help text",
+                    "_valueString": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Hauptbeschwerde Hilfe-Text"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Texte d'aide du motif de consultation"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                                "valueExpression": {
+                                    "language": "text/fhirpath",
+                                    "expression": "'Computed help text'"
+                                }
+                            },
+                            {
+                                "url": "urn:unknown-help-text-extension",
+                                "valueString": "Unknown extension on helpText"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/__tests__/resources/questionnaire_fhir/translation.json
+++ b/src/converter/__tests__/resources/questionnaire_fhir/translation.json
@@ -37,6 +37,42 @@
         {
             "linkId": "chief-complaint",
             "type": "string",
+            "extension": [
+                {
+                    "url": "https://emr-core.beda.software/StructureDefinition/help-text",
+                    "valueString": "Chief complaint help text",
+                    "_valueString": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Hauptbeschwerde Hilfe-Text"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Texte d'aide du motif de consultation"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
             "text": "Chief complaint",
             "_text": {
                 "extension": [
@@ -107,6 +143,42 @@
         {
             "linkId": "pain-level",
             "type": "choice",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
+                    "valueString": "Choose the pain level",
+                    "_valueString": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Wählen Sie die Schmerzintensität"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Choisir le niveau de douleur"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
             "text": "Pain level",
             "_text": {
                 "extension": [
@@ -212,6 +284,67 @@
                             ]
                         }
                     }
+                }
+            ]
+        },
+        {
+            "linkId": "email",
+            "type": "string",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-constraint",
+                    "extension": [
+                        {
+                            "url": "key",
+                            "valueId": "first"
+                        },
+                        {
+                            "url": "human",
+                            "valueString": "Length must be less than 10 characters",
+                            "_valueString": {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                        "extension": [
+                                            {
+                                                "url": "lang",
+                                                "valueCode": "de"
+                                            },
+                                            {
+                                                "url": "content",
+                                                "valueString": "Länge muss weniger als 10 Zeichen sein"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                        "extension": [
+                                            {
+                                                "url": "lang",
+                                                "valueCode": "fr"
+                                            },
+                                            {
+                                                "url": "content",
+                                                "valueString": "La longueur doit être inférieure à 10 caractères"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "url": "severity",
+                            "valueCode": "error"
+                        },
+                        {
+                            "url": "expression",
+                            "valueString": "false"
+                        },
+                        {
+                            "url": "requirements",
+                            "valueString": "Req first"
+                        }
+                    ]
                 }
             ]
         }

--- a/src/converter/extensions.ts
+++ b/src/converter/extensions.ts
@@ -216,13 +216,15 @@ export const extensionTransformers: ExtensionTransformer = {
                 return {
                     itemConstraint: extensions.map((extension) => {
                         const itemConstraintExtension = extension.extension!;
+                        const humanExtension = itemConstraintExtension.find((obj) => obj.url === 'human');
 
                         return {
                             key: itemConstraintExtension.find((obj) => obj.url === 'key')!.valueId!,
                             requirements: itemConstraintExtension.find((obj) => obj.url === 'requirements')
                                 ?.valueString,
                             severity: itemConstraintExtension.find((obj) => obj.url === 'severity')!.valueCode!,
-                            human: itemConstraintExtension.find((obj) => obj.url === 'human')!.valueString!,
+                            human: humanExtension!.valueString!,
+                            ...(humanExtension?._valueString ? { _human: humanExtension._valueString } : {}),
                             expression: itemConstraintExtension.find((obj) => obj.url === 'expression')!.valueString!,
                         };
                     }),
@@ -248,6 +250,7 @@ export const extensionTransformers: ExtensionTransformer = {
                             {
                                 url: 'human',
                                 valueString: itemConstraint?.human,
+                                ...(itemConstraint._human ? { _valueString: itemConstraint._human } : {}),
                             },
                             {
                                 url: 'expression',

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -50,17 +50,13 @@ export function convertToFHIRExtension(item: FCEQuestionnaireItem): FHIRExtensio
                 const underscoreElement = !transformer.path.isCollection ? item[underscoreKey] : undefined;
 
                 extensions.push(
-                    ...valueArray.map((extensionValue) => {
-                        const extension: FHIRExtension = {
-                            [transformer.path.extension]: extensionValue,
-                            url: identifier,
-                        };
-                        if (underscoreElement !== undefined) {
-                            (extension as Record<string, unknown>)[`_${transformer.path.extension}`] =
-                                underscoreElement;
-                        }
-                        return extension;
-                    }),
+                    ...valueArray.map((extensionValue) => ({
+                        [transformer.path.extension]: extensionValue,
+                        url: identifier,
+                        ...(underscoreElement !== undefined
+                            ? { [`_${transformer.path.extension}`]: underscoreElement }
+                            : {}),
+                    })),
                 );
             }
         }

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -15,11 +15,22 @@ export function convertFromFHIRExtension(extensions: FHIRExtension[]): Partial<F
         if ('transform' in transformer) {
             return transformer.transform.fromExtensions(extensions);
         } else {
-            return {
-                [transformer.path.questionnaire]: transformer.path.isCollection
-                    ? extensions.map((extension) => extension[transformer.path.extension])
-                    : extensions[0]![transformer.path.extension],
+            const extensionKey = transformer.path.extension;
+            const questionnaireKey = transformer.path.questionnaire;
+            if (transformer.path.isCollection) {
+                return {
+                    [questionnaireKey]: extensions.map((extension) => extension[extensionKey]),
+                };
+            }
+
+            const result: Record<string, unknown> = {
+                [questionnaireKey]: extensions[0]![extensionKey],
             };
+            const underscoreElement = extensions[0]![`_${extensionKey}` as keyof FHIRExtension];
+            if (underscoreElement !== undefined) {
+                result[`_${questionnaireKey}`] = underscoreElement;
+            }
+            return result as Partial<FCEQuestionnaireItem>;
         }
     }
 }
@@ -35,12 +46,21 @@ export function convertToFHIRExtension(item: FCEQuestionnaireItem): FHIRExtensio
             const value = item[transformer.path.questionnaire];
             if (value !== undefined) {
                 const valueArray = Array.isArray(value) ? value : [value];
+                const underscoreKey = `_${transformer.path.questionnaire}` as keyof FCEQuestionnaireItem;
+                const underscoreElement = !transformer.path.isCollection ? item[underscoreKey] : undefined;
 
                 extensions.push(
-                    ...valueArray.map((extensionValue) => ({
-                        [transformer.path.extension]: extensionValue,
-                        url: identifier,
-                    })),
+                    ...valueArray.map((extensionValue) => {
+                        const extension: FHIRExtension = {
+                            [transformer.path.extension]: extensionValue,
+                            url: identifier,
+                        };
+                        if (underscoreElement !== undefined) {
+                            (extension as Record<string, unknown>)[`_${transformer.path.extension}`] =
+                                underscoreElement;
+                        }
+                        return extension;
+                    }),
                 );
             }
         }

--- a/src/fce.types.ts
+++ b/src/fce.types.ts
@@ -93,6 +93,7 @@ export interface FCEQuestionnaireItem extends QuestionnaireItem {
     /** NOTE: from extension https://jira.hl7.org/browse/FHIR-22356#subQuestionnaire */
     /** Additional instructions for the user to guide their input (i.e. a human readable version of a regular expression like “nnn-nnn-nnn”). In most UIs this is the placeholder (or ‘ghost’) text placed directly inside the edit controls and that disappear when the control gets the focus. */
     entryFormat?: string;
+    _entryFormat?: FCETranslatableElement;
     /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/entryFormat */
     /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/variable */
     /** Variable specifying a logic to generate a variable for use in subsequent logic. The name of the variable will be added to FHIRPath's context when processing descendants of the element that contains this extension. */
@@ -103,6 +104,7 @@ export interface FCEQuestionnaireItem extends QuestionnaireItem {
     start?: number;
     stop?: number;
     helpText?: string;
+    _helpText?: FCETranslatableElement;
     stopLabel?: string;
     rowsNumber?: number;
     colsNumber?: number;
@@ -140,6 +142,12 @@ export interface FCEQuestionnaireItem extends QuestionnaireItem {
 export interface FCETranslation {
     lang: string;
     content: string;
+}
+
+export interface FCETranslatableElement {
+    /** NOTE: from extension http://hl7.org/fhir/StructureDefinition/translation */
+    translation?: FCETranslation[];
+    extension?: Extension[];
 }
 
 export interface FCEQuestionnaireItemText {
@@ -185,6 +193,7 @@ export interface FCEQuestionnaireItemConstraint {
     expression: string;
     /** NOTE: from extension human */
     human: string;
+    _human?: FCETranslatableElement;
     /** NOTE: from extension key */
     key: string;
     /** NOTE: from extension location */


### PR DESCRIPTION
## Summary
- Extend FCE/FHIR translation fixtures with translated `helpText`, `entryFormat`, and item constraint `human` messages so converter coverage includes these extension fields.