### PR TITLE
Add withTranslations flag to toFirstClassExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ P.S. the package was allocated from https://github.com/beda-software/sdc-ide wit
 
 The FHIR ↔ FCE converter supports the [`translation`](http://hl7.org/fhir/StructureDefinition/translation) primitive extension on fields such as `Questionnaire.title` and `Questionnaire.item.text`.
 
+By default, `toFirstClassExtension(questionnaire)` keeps translation extensions in FHIR format (they stay under `extension` and are not promoted to FCE `translation` fields). Pass `withTranslations: true` as the second argument to convert them:
+
+```ts
+import { toFirstClassExtension } from 'sdc-qrf';
+
+// Default: translation extensions stay in FHIR format
+const fceWithoutTranslations = toFirstClassExtension(questionnaire);
+
+// Opt in: convert translation extensions to FCE `translation` fields
+const fceWithTranslations = toFirstClassExtension(questionnaire, true);
+```
+
 **FHIR**
 
 ```yaml
@@ -37,7 +49,7 @@ item:
                       valueString: Motif de consultation
 ```
 
-**FCE** (`toFirstClassExtension` / `fromFirstClassExtension`)
+**FCE** (`toFirstClassExtension(questionnaire, true)` / `fromFirstClassExtension`)
 
 ```yaml
 item:
@@ -59,7 +71,7 @@ To bake a single language into a FHIR Questionnaire before converting to FCE (re
 ```ts
 import { toFirstClassExtension, translateQuestionnaire } from 'sdc-qrf';
 
-const fceQuestionnaire = toFirstClassExtension(translateQuestionnaire(questionnaire, 'fr'));
+const fceQuestionnaire = toFirstClassExtension(translateQuestionnaire(questionnaire, 'fr'), true);
 ```
 
 `translateQuestionnaire(questionnaire, 'fr')` produces:

--- a/src/converter/__tests__/fce.test.ts
+++ b/src/converter/__tests__/fce.test.ts
@@ -39,6 +39,8 @@ import fce_practitioner_role_create from './resources/questionnaire_fce/practiti
 import fce_printable_elements from './resources/questionnaire_fce/printable_elements.json';
 import fce_translation from './resources/questionnaire_fce/translation.json';
 import fce_translation_mixed_extensions from './resources/questionnaire_fce/translation-mixed-extensions.json';
+import fce_translation_skipped from './resources/questionnaire_fce/translation-skipped.json';
+import fce_translation_mixed_extensions_skipped from './resources/questionnaire_fce/translation-mixed-extensions-skipped.json';
 import fce_public_appointment from './resources/questionnaire_fce/public_appointment.json';
 import fce_questionnaire_variable from './resources/questionnaire_fce/questionnaire_variable.json';
 import fce_review_of_systems from './resources/questionnaire_fce/review_of_systems.json';
@@ -154,11 +156,27 @@ describe('Questionanire and QuestionnaireResponses transformation', () => {
         ['column-width', fhir_column_width, fce_column_width],
         ['mapping-inline', fhir_mapping_inline, fce_mapping_inline],
         ['printable-elements', fhir_printable_elements, fce_printable_elements],
-        ['translation', fhir_translation, fce_translation],
-        ['translation-mixed-extensions', fhir_translation_mixed_extensions, fce_translation_mixed_extensions],
+        ['translation-skipped', fhir_translation, fce_translation_skipped],
+        [
+            'translation-mixed-extensions-skipped',
+            fhir_translation_mixed_extensions,
+            fce_translation_mixed_extensions_skipped,
+        ],
     ])('Each FHIR Questionnaire should convert to FCE %s', async (_, fhir_questionnaire, fce_questionnaire) => {
         expect(toFirstClassExtension(fhir_questionnaire as FHIRQuestionnaire)).toStrictEqual(fce_questionnaire);
     });
+
+    test.each([
+        ['translation', fhir_translation, fce_translation],
+        ['translation-mixed-extensions', fhir_translation_mixed_extensions, fce_translation_mixed_extensions],
+    ])(
+        'Each FHIR Questionnaire should convert to FCE with translations %s',
+        async (_, fhir_questionnaire, fce_questionnaire) => {
+            expect(toFirstClassExtension(fhir_questionnaire as FHIRQuestionnaire, true)).toStrictEqual(
+                fce_questionnaire,
+            );
+        },
+    );
 
     test.each([
         ['allergies', fce_allergies, fhir_allergies],

--- a/src/converter/__tests__/resources/questionnaire_fce/translation-mixed-extensions-skipped.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation-mixed-extensions-skipped.json
@@ -1,0 +1,54 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-mixed-extensions",
+    "status": "active",
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "helpText": "Chief complaint help text",
+            "_helpText": {
+                "cqfExpression": {
+                    "language": "text/fhirpath",
+                    "expression": "'Computed help text'"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Hauptbeschwerde Hilfe-Text"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Texte d'aide du motif de consultation"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "urn:unknown-help-text-extension",
+                        "valueString": "Unknown extension on helpText"
+                    }
+                ]
+            }
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/__tests__/resources/questionnaire_fce/translation-skipped.json
+++ b/src/converter/__tests__/resources/questionnaire_fce/translation-skipped.json
@@ -1,0 +1,327 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "translation-example",
+    "status": "active",
+    "title": "Chief complaint form",
+    "_title": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {
+                        "url": "lang",
+                        "valueCode": "de"
+                    },
+                    {
+                        "url": "content",
+                        "valueString": "Formular für Hauptbeschwerde"
+                    }
+                ]
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {
+                        "url": "lang",
+                        "valueCode": "fr"
+                    },
+                    {
+                        "url": "content",
+                        "valueString": "Formulaire de motif de consultation"
+                    }
+                ]
+            }
+        ]
+    },
+    "item": [
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Chief complaint",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Hauptbeschwerde"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Motif de consultation"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "helpText": "Chief complaint help text",
+            "_helpText": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Hauptbeschwerde Hilfe-Text"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Texte d'aide du motif de consultation"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "initial": [
+                {
+                    "valueString": "Headache",
+                    "_valueString": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Kopfschmerzen"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Mal de tête"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "pain-level",
+            "type": "choice",
+            "entryFormat": "Choose the pain level",
+            "_entryFormat": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Wählen Sie die Schmerzintensität"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Choisir le niveau de douleur"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "text": "Pain level",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "de"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Schmerzintensität"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {
+                                "url": "lang",
+                                "valueCode": "fr"
+                            },
+                            {
+                                "url": "content",
+                                "valueString": "Niveau de douleur"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "answerOption": [
+                {
+                    "valueCoding": {
+                        "code": "mild",
+                        "system": "http://example.org/pain-level",
+                        "display": "Mild",
+                        "_display": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "de"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Leicht"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "fr"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Léger"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "valueCoding": {
+                        "code": "severe",
+                        "system": "http://example.org/pain-level",
+                        "display": "Severe",
+                        "_display": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "de"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Schwer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                    "extension": [
+                                        {
+                                            "url": "lang",
+                                            "valueCode": "fr"
+                                        },
+                                        {
+                                            "url": "content",
+                                            "valueString": "Sévère"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "string",
+            "linkId": "email",
+            "itemConstraint": [
+                {
+                    "key": "first",
+                    "requirements": "Req first",
+                    "severity": "error",
+                    "human": "Length must be less than 10 characters",
+                    "_human": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "de"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "Länge muss weniger als 10 Zeichen sein"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {
+                                        "url": "lang",
+                                        "valueCode": "fr"
+                                    },
+                                    {
+                                        "url": "content",
+                                        "valueString": "La longueur doit être inférieure à 10 caractères"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "expression": "false"
+                }
+            ]
+        }
+    ],
+    "meta": {
+        "profile": ["https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire"]
+    }
+}

--- a/src/converter/fhirToFce/index.ts
+++ b/src/converter/fhirToFce/index.ts
@@ -5,6 +5,6 @@ import { convertQuestionnaire } from './questionnaire';
 
 export { translateQuestionnaire } from './translateQuestionnaire';
 
-export function toFirstClassExtension(fhirResource: FHIRQuestionnaire): FCEQuestionnaire {
-    return convertQuestionnaire(fhirResource);
+export function toFirstClassExtension(fhirResource: FHIRQuestionnaire, withTranslations = false): FCEQuestionnaire {
+    return convertQuestionnaire(fhirResource, withTranslations);
 }

--- a/src/converter/fhirToFce/questionnaire/index.ts
+++ b/src/converter/fhirToFce/questionnaire/index.ts
@@ -6,15 +6,15 @@ import { processItems } from './processItems';
 import { checkFhirQuestionnaireProfile, processPrimitiveExtensions, trimUndefined } from '../utils';
 import { FCEQuestionnaire } from '../../../fce.types';
 
-export function convertQuestionnaire(fhirQuestionnaire: FHIRQuestionnaire): FCEQuestionnaire {
+export function convertQuestionnaire(fhirQuestionnaire: FHIRQuestionnaire, withTranslations = false): FCEQuestionnaire {
     checkFhirQuestionnaireProfile(fhirQuestionnaire);
     fhirQuestionnaire = cloneDeep(fhirQuestionnaire);
-    const processedItem = processItems(fhirQuestionnaire);
+    const processedItem = processItems(fhirQuestionnaire, withTranslations);
     const extensions = processExtensions(fhirQuestionnaire);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { item: _item, ...rest } = fhirQuestionnaire;
     const questionnaire = trimUndefined({
-        ...processPrimitiveExtensions(rest),
+        ...processPrimitiveExtensions(rest, withTranslations),
         item: processedItem,
         ...extensions,
         extension: undefined,

--- a/src/converter/fhirToFce/questionnaire/processItems.ts
+++ b/src/converter/fhirToFce/questionnaire/processItems.ts
@@ -3,16 +3,19 @@ import { Questionnaire as FHIRQuestionnaire, QuestionnaireItem as FHIRQuestionna
 import { processExtensibleElement, processPrimitiveExtensions } from '../utils';
 import { FCEQuestionnaireItem } from '../../../fce.types';
 
-export function processItems(fhirQuestionnaire: FHIRQuestionnaire) {
-    return fhirQuestionnaire.item?.map((item) => convertItemProperties(item));
+export function processItems(fhirQuestionnaire: FHIRQuestionnaire, withTranslations = false) {
+    return fhirQuestionnaire.item?.map((item) => convertItemProperties(item, withTranslations));
 }
 
-function convertItemProperties(item: FHIRQuestionnaireItem): FCEQuestionnaireItem {
+function convertItemProperties(item: FHIRQuestionnaireItem, withTranslations = false): FCEQuestionnaireItem {
     const { item: nestedItems, ...rest } = item;
-    const newItem = processExtensibleElement(processPrimitiveExtensions(rest)) as FCEQuestionnaireItem;
+    const newItem = processExtensibleElement(
+        processPrimitiveExtensions(rest, withTranslations),
+        withTranslations,
+    ) as FCEQuestionnaireItem;
 
     if (nestedItems) {
-        newItem.item = nestedItems.map((nestedItem) => convertItemProperties(nestedItem));
+        newItem.item = nestedItems.map((nestedItem) => convertItemProperties(nestedItem, withTranslations));
     }
 
     return newItem;

--- a/src/converter/fhirToFce/utils.ts
+++ b/src/converter/fhirToFce/utils.ts
@@ -38,9 +38,14 @@ export function trimUndefined(e: any) {
     return e;
 }
 
-export function processExtensibleElement<T extends { extension?: Extension[] }>(element: T): T {
+export function processExtensibleElement<T extends { extension?: Extension[] }>(
+    element: T,
+    withTranslations = false,
+): T {
     let newElement = { ...element };
-    const knownExtensionUrls = Object.values(ExtensionIdentifier) as string[];
+    const knownExtensionUrls = (Object.values(ExtensionIdentifier) as string[]).filter(
+        (url) => withTranslations || url !== ExtensionIdentifier.Translation,
+    );
 
     const allExtensions = element.extension ?? [];
     const knownExtensions = allExtensions.filter((ext) => knownExtensionUrls.includes(ext.url));
@@ -67,19 +72,19 @@ export function processExtensibleElement<T extends { extension?: Extension[] }>(
     return newElement;
 }
 
-export function processPrimitiveExtensions<T>(resource: T): T {
-    walk(resource);
+export function processPrimitiveExtensions<T>(resource: T, withTranslations = false): T {
+    walk(resource, withTranslations);
     return resource;
 }
 
-function walk(node: unknown): void {
+function walk(node: unknown, withTranslations = false): void {
     if (node === null || typeof node !== 'object') {
         return;
     }
 
     if (Array.isArray(node)) {
         for (const item of node) {
-            walk(item);
+            walk(item, withTranslations);
         }
         return;
     }
@@ -90,9 +95,9 @@ function walk(node: unknown): void {
         const value = object[property];
 
         if (property.startsWith('_') && value instanceof Object && !Array.isArray(value)) {
-            object[property] = processExtensibleElement(value as { extension?: Extension[] });
+            object[property] = processExtensibleElement(value as { extension?: Extension[] }, withTranslations);
         } else {
-            walk(value);
+            walk(value, withTranslations);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `withTranslations` (default `false`) to `toFirstClassExtension` so translation extensions stay in FHIR format unless callers opt in
- Thread the flag through the FHIR→FCE conversion pipeline; `true` preserves the previous FCE `translation` conversion behavior
- Update tests and README to cover both default and opt-in paths